### PR TITLE
Handle closing double quote

### DIFF
--- a/src/FolkerKinzel.CsvTools/Intls/CsvStringReader.cs
+++ b/src/FolkerKinzel.CsvTools/Intls/CsvStringReader.cs
@@ -168,6 +168,8 @@ namespace FolkerKinzel.CsvTools.Intls
                         {
                             if (c == '\"')
                             {
+                                isQuoted = !isQuoted;
+
                                 if (isMaskedDoubleQuote)
                                 {
                                     isMaskedDoubleQuote = false;


### PR DESCRIPTION
Hey Folker.
I noticed an unhandled use case while using your library. 
I tried to fix it and here is the proposed solution.
I hope you find the time and review it and maybe discuss it together.

The string i was trying to parse has a template like so 1234|4567|"DemoString" Some more demo string|
While the code detected an opening double quote(that is when the value starts with a ") it failed to do so on the closing double quote and that led to some parsing and reading issues